### PR TITLE
add button to remove once per day spells

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -216,8 +216,14 @@
 <!-- once per days -->
 <section>
   <div class="m0a">
-    {#each cd.onePerDays as spell}
+    {#each cd.onePerDays as spell, index}
       <div class="flex" transition:fly={{ duration: 100, y: -10 }}>
+        <button
+          onclick={() => {
+            cd.onePerDays.splice(index, 1);
+            save();
+          }}
+        >-</button>
         <input
           class="box field"
           type="text"


### PR DESCRIPTION
A small PR that adds a button to remove a once-per-day spell.

I was playing around with the app and realized that once you add a once-per-day spell, there's no easy way to remove it (other than deleting it from localStorage.

Thanks for the cool little app.

_edit_: I've added a few more changes on [my fork](https://github.com/jaquer/spellSlotTracker). Let me know if you're interested in me making PRs to any of them. Or you can just grab any changes and tweak them to match your style, of course. Thanks again.
